### PR TITLE
Expose whether limit is met on limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/openfaas/faas-middleware
+
+go 1.18


### PR DESCRIPTION
## Description

Expose whether limit is met on limiter

This change allows the limiter to be used in a health check handler or other supervising code to determine if a limit has been met or not.

Previously the API was encapsulated with a HTTP handler and private.

## How has this been tested

Tested with a unit test and end to end with the of-watchdog in a temporary patch.

This is how I'd see it being used in the of-watchdog's ready endpoint:

```golang

func main() {

	requestHandler := buildRequestHandler(watchdogConfig, watchdogConfig.PrefixLogs)

	var limit *limiter.ConcurrencyLimiter
	if watchdogConfig.MaxInflight > 0 {
		limit = limiter.NewConcurrencyLimiter(requestHandler, watchdogConfig.MaxInflight)
		requestHandler = limit.Handler()
	}

	http.HandleFunc("/_/ready", makeReadyHandler(limit))
}

func makeReadyHandler(limit *limiter.ConcurrencyLimiter) func(http.ResponseWriter, *http.Request) {
	return func(w http.ResponseWriter, r *http.Request) {
		switch r.Method {
		case http.MethodGet:
			status := http.StatusOK

			if atomic.LoadInt32(&acceptingConnections) == 0 || !lockFilePresent() {
				status = http.StatusServiceUnavailable
			} else if limit != nil {
				if limit.Met() {
					status = http.StatusTooManyRequests
				}
			}

			w.WriteHeader(status)
		default:
			w.WriteHeader(http.StatusMethodNotAllowed)
		}
	}
}
```
