### PR TITLE
feat: allow functional nil limiter.Met implementation

### DIFF
--- a/concurrency-limiter/concurrency_limiter.go
+++ b/concurrency-limiter/concurrency_limiter.go
@@ -39,6 +39,10 @@ type ConcurrencyLimiter struct {
 }
 
 func (cl *ConcurrencyLimiter) Met() bool {
+	if cl == nil {
+		return false
+	}
+
 	// We should not have any ConcurrencyLimiter created with a limit of 0
 	// but return early if that's the case.
 	if cl.maxInflightRequests == 0 {

--- a/concurrency-limiter/concurrency_limiter_test.go
+++ b/concurrency-limiter/concurrency_limiter_test.go
@@ -11,6 +11,13 @@ import (
 	"time"
 )
 
+func Test_Met_FalseWhenNil(t *testing.T) {
+	var cl *ConcurrencyLimiter
+	if cl.Met() != false {
+		t.Fatalf("Want Met() to be false when nil, got: %t", cl.Met())
+	}
+}
+
 func Test_Met_FalseWhenNoLimitSet(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Ensure that `Met()` is functional and `false` when the limiter is nil. This makes it a bit easier to work with because you can assume the `cl.Met` is always callable. Reducing the number of required nil checks.

This is helpful to simplify the implementation for https://github.com/openfaas/of-watchdog/issues/144